### PR TITLE
fix: close D-Bus bus on device-initiated BLE disconnect to prevent connection leak

### DIFF
--- a/custom_components/quietcool_ble/api.py
+++ b/custom_components/quietcool_ble/api.py
@@ -219,12 +219,32 @@ async def safe_disconnect(client: BleakClient, label: str = "") -> None:
             label or client.address,
             DISCONNECT_TIMEOUT,
         )
+        _force_close_bus(client)
     except Exception as err:  # noqa: BLE001 — teardown must never raise
         _LOGGER.debug(
             "QuietCool %s: error during BLE disconnect (ignored): %s",
             label or client.address,
             err,
         )
+        _force_close_bus(client)
+
+
+def _force_close_bus(client: BleakClient) -> None:
+    """Force-close a BleakClient's D-Bus bus to prevent connection leak.
+
+    Bleak's _cleanup_all() does not close the per-client D-Bus MessageBus when
+    the BLE device disconnects on its own, leaking one Unix socket to dbus-daemon
+    per reconnect cycle.  This reaches into Bleak internals as a last resort when
+    the normal disconnect() path fails or was never called.
+    """
+    try:
+        backend = getattr(client, "_backend", None)
+        bus = getattr(backend, "_bus", None) if backend else None
+        if bus is not None:
+            bus.disconnect()
+            _LOGGER.debug("QuietCool: force-closed leaked D-Bus bus")
+    except Exception:  # noqa: BLE001 — best-effort cleanup
+        pass
 
 
 async def login(client: BleakClient, phone_id: str) -> bool:

--- a/custom_components/quietcool_ble/coordinator.py
+++ b/custom_components/quietcool_ble/coordinator.py
@@ -38,6 +38,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from . import api
 from .api import FanInfo, FanParameters, FanState, FanVersion
 from .const import (
+    DISCONNECT_TIMEOUT,
     KEEP_ALIVE_SECONDS,
     MAX_CONNECT_ATTEMPTS,
     POLL_INTERVAL_SECONDS,
@@ -514,8 +515,26 @@ class QuietCoolBLECoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
             self._idle_timer_handle = None
         if self._poll_task and not self._poll_task.done():
             self._poll_task.cancel()
+        # Close the old client's D-Bus bus to prevent dbus-daemon connection leak.
+        # Bleak's _cleanup_all() fires on unsolicited BLE disconnects but does not
+        # close the per-client D-Bus MessageBus, leaking one connection per cycle.
+        self.hass.async_create_task(self._async_close_stale_client(client))
         # Schedule next poll — device returns to advertising mode after disconnect
         self._schedule_poll_timer()
+
+    async def _async_close_stale_client(self, client: BleakClient) -> None:
+        """Close a stale BleakClient's D-Bus bus after device-initiated disconnect.
+
+        Bleak's _cleanup_all() fires on unsolicited BLE disconnects but does not
+        close the per-client D-Bus MessageBus, leaking one dbus-daemon connection
+        per BLE reconnect cycle.  Calling disconnect() on an already-disconnected
+        client is safe — Bleak skips the BLE teardown and goes straight to
+        bus.disconnect().
+        """
+        try:
+            await asyncio.wait_for(client.disconnect(), timeout=DISCONNECT_TIMEOUT)
+        except Exception:  # noqa: BLE001
+            api._force_close_bus(client)
 
     def _schedule_poll_timer(self) -> None:
         """Schedule a timer-driven poll for after device disconnects.


### PR DESCRIPTION
## Problem

Bleak creates a new D-Bus `MessageBus` per BLE connection session (intentional — works around a BlueZ notification quirk), but its `_cleanup_all()` does **not** close the bus when the BLE device disconnects on its own.  The asyncio event loop holds a reference to the orphaned bus via its fd reader callback, preventing garbage collection.  Each leaked bus holds one open Unix socket to `/run/dbus/system_bus_socket`.

The QuietCool fan drops idle BLE connections every ~25 seconds.  After 256 reconnect cycles (~1.7 hours), the dbus-daemon's default `max_connections_per_user=256` limit is hit — **permanently killing all Bluetooth** until HA is restarted.

### Symptoms
- Entities go **unavailable** within minutes/hours and never recover
- HA logs flood with `[Errno 9] Bad file descriptor` and `EOFError` from `bleak.backends.bluezdbus.client`
- `journalctl -u dbus` shows: `The maximum number of active connections for UID 0 has been reached (max_connections_per_user=256)`
- `dmesg` shows repeated `Bluetooth: hci0: Opcode 0x2013 failed: -16`
- **Only a full HA restart** recovers; reload does not help
- BLE advertisements continue to arrive — Bluetooth hardware is fine, but the D-Bus connection from inside the container is dead

### Root cause trace

```
QuietCool polls every 10s → fan idles and drops BLE after ~25s
  → Bleak fires on_connected_changed(False)
    → _cleanup_all() runs — removes watcher, resets services
    → DOES NOT call self._bus.disconnect()  ← THE BUG (in Bleak)
    → DOES NOT set self._bus = None
  → Integration creates new BleakClient with new D-Bus bus
  → Old D-Bus bus orphaned: event loop holds fd reader → prevents GC
  → Each orphaned bus = 1 Unix socket to dbus-daemon
  → After ~256 cycles → max_connections_per_user=256 hit
  → dbus-daemon rejects ALL new connections
  → Bleak can't talk to BlueZ → Bad file descriptor / EOFError
  → Integration retries at 5min backoff but can never reconnect
```

## Fix

### `_handle_disconnect()` — close old client's D-Bus bus (main fix)

When the fan drops the BLE connection, `_handle_disconnect` now schedules `_async_close_stale_client()` which calls `client.disconnect()` on the old `BleakClient`. This is safe on an already-BLE-disconnected client — Bleak skips the BLE teardown step and goes straight to `self._bus.disconnect()` → `self._bus = None`, releasing the leaked D-Bus socket.

### `safe_disconnect()` — force-close on timeout (fallback)

When `disconnect()` times out or raises (the transport-wedge scenario from #10), the new `_force_close_bus()` helper reaches into Bleak's private `_backend._bus` to close the D-Bus bus directly.  This is a last-resort fallback — the primary path uses Bleak's public `disconnect()` API.

## Testing

Tested on **Raspberry Pi 5** (Docker, onboard hci0 Bluetooth) with an **AFG SMT ES-3.0** (firmware V4.1, V2 protocol).

| Metric | Before | After |
|--------|--------|-------|
| D-Bus connections over 5 min | 14 → 17 → grew continuously | **13 → 13 (flat)** |
| D-Bus `max_connections` errors | 2,461 total since boot | **0** |
| `Bad file descriptor` in HA logs | Continuous every 5 min | **0** |
| Fan polling | Dead after ~2 hours | **Stable indefinitely** |

### Note

The underlying bug is in Bleak's `_cleanup_all()` (`bleak/backends/bluezdbus/client.py`), which should close the D-Bus bus when the BLE device disconnects.  This PR works around it at the integration level.  Users on Raspberry Pi / Docker may also benefit from raising the dbus-daemon limit as defense-in-depth:

```xml
<!-- /etc/dbus-1/system-local.conf -->
<busconfig>
  <limit name="max_connections_per_user">4096</limit>
</busconfig>
```